### PR TITLE
Update utils.py

### DIFF
--- a/django/contrib/admindocs/utils.py
+++ b/django/contrib/admindocs/utils.py
@@ -33,7 +33,7 @@ def trim_docstring(docstring):
         return ''
     # Convert tabs to spaces and split into lines
     lines = docstring.expandtabs().splitlines()
-    indent = min(len(line) - len(line.lstrip()) for line in lines if line.lstrip())
+    indent = min((len(line) - len(line.lstrip()) for line in lines[1:] if line.lstrip()), default=0)
     trimmed = [lines[0].lstrip()] + [line[indent:].rstrip() for line in lines[1:]]
     return "\n".join(trimmed).strip()
 


### PR DESCRIPTION
Make admindocs work with docstrings with the first line not empty.  As an example:

```python
class Test(models.Model):
    """"First line.
    Second line.
    """
```